### PR TITLE
SDGsアイコンの表示

### DIFF
--- a/components/sdgsDisplayGenerator.js
+++ b/components/sdgsDisplayGenerator.js
@@ -1,0 +1,48 @@
+export const sdgsDisplayGenerator = (sdgsObj) => {
+  const sdgsGoals = Object.entries(sdgsObj).map(([key, value]) => ({
+    name: key,
+    display: value,
+  }));
+  return sdgsGoals;
+};
+
+export const sdgsIconSwitch = (name) => {
+  switch (name) {
+    case "goal01":
+      return "/images/icon/sdg_icon_01_ja.png";
+    case "goal02":
+      return "/images/icon/sdg_icon_02_ja.png";
+    case "goal03":
+      return "/images/icon/sdg_icon_03_ja.png";
+    case "goal04":
+      return "/images/icon/sdg_icon_04_ja.png";
+    case "goal05":
+      return "/images/icon/sdg_icon_05_ja.png";
+    case "goal06":
+      return "/images/icon/sdg_icon_06_ja.png";
+    case "goal07":
+      return "/images/icon/sdg_icon_07_ja.png";
+    case "goal08":
+      return "/images/icon/sdg_icon_08_ja.png";
+    case "goal09":
+      return "/images/icon/sdg_icon_09_ja.png";
+    case "goal10":
+      return "/images/icon/sdg_icon_10_ja.png";
+    case "goal11":
+      return "/images/icon/sdg_icon_11_ja.png";
+    case "goal12":
+      return "/images/icon/sdg_icon_12_ja.png";
+    case "goal13":
+      return "/images/icon/sdg_icon_13_ja.png";
+    case "goal14":
+      return "/images/icon/sdg_icon_14_ja.png";
+    case "goal15":
+      return "/images/icon/sdg_icon_15_ja.png";
+    case "goal16":
+      return "/images/icon/sdg_icon_16_ja.png";
+    case "goal17":
+      return "/images/icon/sdg_icon_17_ja.png";
+    default:
+      return "";
+  }
+};

--- a/pages/articles/[uid].js
+++ b/pages/articles/[uid].js
@@ -1,235 +1,348 @@
 //pages/[uid].js
-import React, {useState, useEffect} from "react";
-import styles from '../../styles/articles.module.scss'
-import Image from 'next/image'
-import Link from 'next/link'
-import PageHero from '../../components/PageHero'
-import { RichText, LinkResolver } from 'prismic-reactjs';
-import Prismic from '@prismicio/client'
+import React, { useState, useEffect } from "react";
+import styles from "../../styles/articles.module.scss";
+import Image from "next/image";
+import Link from "next/link";
+import PageHero from "../../components/PageHero";
+import { RichText, LinkResolver } from "prismic-reactjs";
+import Prismic from "@prismicio/client";
 import { Client } from "../../prismic-configuration";
 import { queryRepeatableDocuments } from "../../util/queries";
-
+import {
+  sdgsDisplayGenerator,
+  sdgsIconSwitch,
+} from "../../components/sdgsDisplayGenerator";
 const Article = ({ doc, articles }) => {
-    const [pickUpArticles, setPicUpArticles] = useState([]);
-    const apiEndpoint = process.env.NEXT_PUBLIC_PRISMIC_API_END_POINT;
-  
-    useEffect(() => {
-      const fetchData = async () => {
-        const client = Client();
-        const articles = await client.query(Prismic.predicates.at("document.type", "article"),{
-          orderings : '[document.last_publication_date desc]',
-          pageSize: 2
-        })
-        if (articles) {
-          const pickUpArticleResults = articles.results
-          setPicUpArticles(pickUpArticleResults)
+  const [pickUpArticles, setPicUpArticles] = useState([]);
+  const apiEndpoint = process.env.NEXT_PUBLIC_PRISMIC_API_END_POINT;
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const client = Client();
+      const articles = await client.query(
+        Prismic.predicates.at("document.type", "article"),
+        {
+          orderings: "[document.last_publication_date desc]",
+          pageSize: 2,
         }
-      };
-      fetchData();
-    }, []);
+      );
+      if (articles) {
+        const pickUpArticleResults = articles.results;
+        setPicUpArticles(pickUpArticleResults);
+      }
+    };
+    fetchData();
+  }, []);
+  console.log(doc);
+  console.log(doc.data);
 
   if (doc && doc.data) {
-    const dt = new Date(doc.first_publication_date)
-    const year = dt.getFullYear()
-    const month = ('00' + (dt.getMonth() + 1)).slice(-2)
-    const date = ('00' + dt.getDate()).slice(-2)
-    const publishDate = `${year}.${month}.${date}`
+    const dt = new Date(doc.first_publication_date);
+    const year = dt.getFullYear();
+    const month = ("00" + (dt.getMonth() + 1)).slice(-2);
+    const date = ("00" + dt.getDate()).slice(-2);
+    const publishDate = `${year}.${month}.${date}`;
     const hasTitle = doc.data.title.length !== 0;
+    const hasGroup = doc.data.group.length !== 0;
     const hasContent = doc.data.content.length !== 0;
     const hasInterviweeName = doc.data.interviewee_name.length !== 0;
     const hasEditorName = doc.data.editor_name.length !== 0;
     const hasInterviweeProfile = doc.data.interviewee_profile.length !== 0;
     const hasEditorProfile = doc.data.editor_profile.length !== 0;
-    const hasIntervieweePic = 'url' in doc.data.interviewee_pic
-    const hasEditorPic = 'url' in doc.data.editor_pic
-    const hasInterviweeLink = 'url' in doc.data.interviewee_link
-    const hasEditorLink = 'url' in doc.data.editor_link
+    const hasIntervieweePic = "url" in doc.data.interviewee_pic;
+    const hasEditorPic = "url" in doc.data.editor_pic;
+    const hasInterviweeLink = "url" in doc.data.interviewee_link;
+    const hasEditorLink = "url" in doc.data.editor_link;
     const title = hasTitle ? RichText.asText(doc.data.title) : "Untitled";
-    const content = hasContent ? RichText.render(doc.data.content, LinkResolver) : "";
-    const interviewee_name = hasInterviweeName ? RichText.asText(doc.data.interviewee_name) : "NoName";
-    const editor_name = hasEditorName ? RichText.render(doc.data.editor_name, LinkResolver) : "NoName";
-    const interviewee_profile = hasInterviweeProfile ? RichText.asText(doc.data.interviewee_profile) : "NoContent";
-    const editor_profile = hasEditorProfile ? RichText.render(doc.data.editor_profile, LinkResolver) : "NoContent";
-    const interviewee_link = hasInterviweeLink ? doc.data.interviewee_link.url : "" ;
-    const editor_link = hasEditorLink ? doc.data.editor_link.url : "" ;
-  return (
-    <>
-      <PageHero imagePath={doc.data.eyecatch.url}/>
-      <section className={styles.articlesdetail}>
-        <div className={styles.articlesdetail__container}>
-          <div className={styles.articlesdetail__heading}>
-            <div className={styles.articlesdetail__heading__top}>
-              <p className={styles.articlesdetail__heading__category}>{doc.data.categories}</p>
-              <p className={styles.articlesdetail__heading__time}>{publishDate}</p>
-            </div>
-            <div className={styles.articlesdetail__heading__bottom}>
-              <div className={styles.articlesdetail__heading__left}>
-                <h1 className={styles.articlesdetail__heading__title}>{title}</h1>
-                <ul className={styles.articlesdetail__heading__hashList}>
-                  {
-                    doc.tags.map((tag) => {
+    const content = hasContent
+      ? RichText.render(doc.data.content, LinkResolver)
+      : "";
+    const interviewee_name = hasInterviweeName
+      ? RichText.asText(doc.data.interviewee_name)
+      : "NoName";
+    const editor_name = hasEditorName
+      ? RichText.render(doc.data.editor_name, LinkResolver)
+      : "NoName";
+    const interviewee_profile = hasInterviweeProfile
+      ? RichText.asText(doc.data.interviewee_profile)
+      : "NoContent";
+    const editor_profile = hasEditorProfile
+      ? RichText.render(doc.data.editor_profile, LinkResolver)
+      : "NoContent";
+    const interviewee_link = hasInterviweeLink
+      ? doc.data.interviewee_link.url
+      : "";
+    const editor_link = hasEditorLink ? doc.data.editor_link.url : "";
+    const SDGsGoals = hasGroup ? sdgsDisplayGenerator(doc.data.group[0]) : [];
+    console.log(SDGsGoals);
+
+    return (
+      <>
+        <PageHero imagePath={doc.data.eyecatch.url} />
+        <section className={styles.articlesdetail}>
+          <div className={styles.articlesdetail__container}>
+            <div className={styles.articlesdetail__heading}>
+              <div className={styles.articlesdetail__heading__top}>
+                <p className={styles.articlesdetail__heading__category}>
+                  {doc.data.categories}
+                </p>
+                <p className={styles.articlesdetail__heading__time}>
+                  {publishDate}
+                </p>
+              </div>
+              <div className={styles.articlesdetail__heading__bottom}>
+                <div className={styles.articlesdetail__heading__left}>
+                  <h1 className={styles.articlesdetail__heading__title}>
+                    {title}
+                  </h1>
+                  <ul className={styles.articlesdetail__heading__hashList}>
+                    {doc.tags.map((tag) => {
                       return (
-                        <li className={styles.articlesdetail__heading__hashItem}>
+                        <li
+                          className={styles.articlesdetail__heading__hashItem}
+                        >
                           <Link href="/">
-                            <a className={styles.articlesdetail__heading__hashLink}>{`#${tag}`}</a>
+                            <a
+                              className={
+                                styles.articlesdetail__heading__hashLink
+                              }
+                            >{`#${tag}`}</a>
                           </Link>
                         </li>
-                      )
-                    })
-                  }
-                </ul>
-                <ul className={styles.articlesdetail__heading__icon}>
-                  <li className={styles.articlesdetail__heading__iconItem}>
-                    <Image src="/images/icon/sdg_icon_01_ja.png" quality={100} width={1276} height={1276} />
+                      );
+                    })}
+                  </ul>
+                  <ul className={styles.articlesdetail__heading__icon}>
+                    {SDGsGoals &&
+                      SDGsGoals.map((value) => {
+                        if (value.display) {
+                          return (
+                            <li
+                              className={
+                                styles.articlesdetail__heading__iconItem
+                              }
+                            >
+                              <Image
+                                src={sdgsIconSwitch(value.name)}
+                                quality={100}
+                                width={1276}
+                                height={1276}
+                              />
+                            </li>
+                          );
+                        }
+                      })}
+                  </ul>
+                </div>
+                <ul className={styles.articlesdetail__heading__snsList}>
+                  <li className={styles.articlesdetail__heading__snsItem}>
+                    <Link href="/">
+                      <a className={styles.articlesdetail__heading__snsLink}>
+                        <div className={styles.articlesdetail__heading__snsImg}>
+                          <Image
+                            src="/images/icon/icon_fb_gr.png"
+                            quality={100}
+                            width={75}
+                            height={150}
+                          />
+                        </div>
+                      </a>
+                    </Link>
                   </li>
-                  <li className={styles.articlesdetail__heading__iconItem}>
-                    <Image src="/images/icon/sdg_icon_02_ja.png" quality={100} width={1276} height={1276} />
-                  </li>
-                  <li className={styles.articlesdetail__heading__iconItem}>
-                    <Image src="/images/icon/sdg_icon_01_ja.png" quality={100} width={1276} height={1276} />
-                  </li>
-                  <li className={styles.articlesdetail__heading__iconItem}>
-                    <Image src="/images/icon/sdg_icon_02_ja.png" quality={100} width={1276} height={1276} />
-                  </li>
-                  <li className={styles.articlesdetail__heading__iconItem}>
-                    <Image src="/images/icon/sdg_icon_01_ja.png" quality={100} width={1276} height={1276} />
-                  </li>
-                  <li className={styles.articlesdetail__heading__iconItem}>
-                    <Image src="/images/icon/sdg_icon_02_ja.png" quality={100} width={1276} height={1276} />
-                  </li>
-                  <li className={styles.articlesdetail__heading__iconItem}>
-                    <Image src="/images/icon/sdg_icon_01_ja.png" quality={100} width={1276} height={1276} />
-                  </li>
-                  <li className={styles.articlesdetail__heading__iconItem}>
-                    <Image src="/images/icon/sdg_icon_02_ja.png" quality={100} width={1276} height={1276} />
+                  <li className={styles.articlesdetail__heading__snsItem}>
+                    <Link href="/">
+                      <a className={styles.articlesdetail__heading__snsLink}>
+                        <div className={styles.articlesdetail__heading__snsImg}>
+                          <Image
+                            src="/images/icon/icon_tw_gr.png"
+                            quality={100}
+                            width={150}
+                            height={120}
+                          />
+                        </div>
+                      </a>
+                    </Link>
                   </li>
                 </ul>
               </div>
-              <ul className={styles.articlesdetail__heading__snsList}>
-                <li className={styles.articlesdetail__heading__snsItem}>
-                  <Link href="/">
-                    <a className={styles.articlesdetail__heading__snsLink}>
-                      <div className={styles.articlesdetail__heading__snsImg}>
-                        <Image src="/images/icon/icon_fb_gr.png" quality={100} width={75} height={150} />
-                      </div>
-                    </a>
-                  </Link>
-                </li>
-                <li className={styles.articlesdetail__heading__snsItem}>
-                  <Link href="/">
-                    <a className={styles.articlesdetail__heading__snsLink}>
-                      <div className={styles.articlesdetail__heading__snsImg}>
-                        <Image src="/images/icon/icon_tw_gr.png" quality={100} width={150} height={120} />
-                      </div>
-                    </a>
-                  </Link>
-                </li>
-              </ul>
+            </div>
+            <div className={styles.articlesdetail__content}>{content}</div>
+            <div className={styles.articlesdetail__relatedLink}>
+              <h2 className={styles.articlesdetail__relatedLink__heading}>
+                {interviewee_name}
+              </h2>
+              <div className={styles.articlesdetail__relatedLink__img}>
+                {hasIntervieweePic ? (
+                  <Image
+                    src={doc.data.interviewee_pic.url}
+                    quality={100}
+                    width={321}
+                    height={322}
+                  />
+                ) : (
+                  <Image
+                    src="/images/noimage.png"
+                    quality={100}
+                    width={321}
+                    height={322}
+                  />
+                )}
+              </div>
+              <p className={styles.articlesdetail__relatedLink__desc}>
+                {interviewee_profile}
+              </p>
+              {hasInterviweeLink && (
+                <a
+                  href={interviewee_link}
+                  className={styles.articlesdetail__relatedLink__link}
+                  target="_blank"
+                >
+                  URL：{`${interviewee_link}`}
+                </a>
+              )}
+            </div>
+            <div className={styles.articlesdetail__editor}>
+              <div className={styles.articlesdetail__editor__img}>
+                {hasEditorPic ? (
+                  <Image
+                    src={doc.data.editor_pic.url}
+                    quality={100}
+                    width={321}
+                    height={322}
+                  />
+                ) : (
+                  <Image
+                    src="/images/noimage.png"
+                    quality={100}
+                    width={321}
+                    height={322}
+                  />
+                )}
+              </div>
+              <div className={styles.articlesdetail__editor__heading}>
+                {editor_name}
+              </div>
+              <p className={styles.articlesdetail__editor__desc}>
+                {editor_profile}
+              </p>
+              {hasEditorLink && (
+                <a
+                  href={editor_link}
+                  className={styles.articlesdetail__editor__link}
+                  target="_blank"
+                >
+                  URL：{`${editor_link}`}
+                </a>
+              )}
             </div>
           </div>
-          <div className={styles.articlesdetail__content}>{content}</div>
-          <div className={styles.articlesdetail__relatedLink}>
-            <h2 className={styles.articlesdetail__relatedLink__heading}>{interviewee_name}</h2>
-            <div className={styles.articlesdetail__relatedLink__img}>
-              {
-                hasIntervieweePic ?
-                <Image src={doc.data.interviewee_pic.url} quality={100} width={321} height={322} />
-                :
-                <Image src='/images/noimage.png' quality={100} width={321} height={322} />
-              }
+          <div className={styles.articlesdetail__pickup}>
+            <div className={styles.articlesdetail__pickup__heading}>
+              <h2 className={styles.articlesdetail__pickup__heading__en}>
+                Pick Up
+              </h2>
+              <p className={styles.articlesdetail__pickup__heading__desc}>
+                合わせて読みたいオススメ記事
+              </p>
             </div>
-            <p className={styles.articlesdetail__relatedLink__desc}>{interviewee_profile}</p>
-            {
-              hasInterviweeLink &&
-              <a href={interviewee_link} className={styles.articlesdetail__relatedLink__link} target="_blank">URL：{`${interviewee_link}`}</a>
-            }
-          </div>    
-          <div className={styles.articlesdetail__editor}>
-            <div className={styles.articlesdetail__editor__img}>
-              {
-                hasEditorPic ?
-                <Image src={doc.data.editor_pic.url} quality={100} width={321} height={322} />
-                :
-                <Image src='/images/noimage.png' quality={100} width={321} height={322} />
-              }
-            </div>
-            <div className={styles.articlesdetail__editor__heading}>{editor_name}</div>
-            <p className={styles.articlesdetail__editor__desc}>{editor_profile}</p>
-            {
-              hasEditorLink &&
-              <a href={editor_link} className={styles.articlesdetail__editor__link} target="_blank">URL：{`${editor_link}`}</a>
-            }
-          </div>
-        </div>
-        <div className={styles.articlesdetail__pickup}>
-          <div className={styles.articlesdetail__pickup__heading}>
-            <h2 className={styles.articlesdetail__pickup__heading__en}>Pick Up</h2>
-            <p className={styles.articlesdetail__pickup__heading__desc}>合わせて読みたいオススメ記事</p>
-          </div>
-          <div className={styles.articlesdetail__pickup__listBlock}>
-            <ul className={styles.articlesdetail__pickup__list}>
-              {
-                pickUpArticles.map(article => {
-                    const uid = article.uid
-                    const title = article.data.title[0].text
-                    const category = article.data.categories
-                    const tags = article.tags
-                    const eyecatch = article.data.eyecatch.url
+            <div className={styles.articlesdetail__pickup__listBlock}>
+              <ul className={styles.articlesdetail__pickup__list}>
+                {pickUpArticles.map((article) => {
+                  const uid = article.uid;
+                  const title = article.data.title[0].text;
+                  const category = article.data.categories;
+                  const tags = article.tags;
+                  const eyecatch = article.data.eyecatch.url;
                   return (
                     <li className={styles.articlesdetail__pickup__item}>
                       <Link href={`/articles/${uid}`}>
                         <a className={styles.articlesdetail__pickup__link}>
                           <div className={styles.articlesdetail__pickup__img}>
-                            <Image src={eyecatch ? eyecatch : '/images/noimage.png'} quality={100} width={600} height={400} />
+                            <Image
+                              src={eyecatch ? eyecatch : "/images/noimage.png"}
+                              quality={100}
+                              width={600}
+                              height={400}
+                            />
                           </div>
-                          <ul className={styles.articlesdetail__pickup__category}>
-                            <li className={styles.articlesdetail__pickup__category__item}>{category}</li>
+                          <ul
+                            className={styles.articlesdetail__pickup__category}
+                          >
+                            <li
+                              className={
+                                styles.articlesdetail__pickup__category__item
+                              }
+                            >
+                              {category}
+                            </li>
                           </ul>
-                          <h3 className={styles.articlesdetail__pickup__item__heading}>{title}</h3>
+                          <h3
+                            className={
+                              styles.articlesdetail__pickup__item__heading
+                            }
+                          >
+                            {title}
+                          </h3>
                         </a>
                       </Link>
                       <ul className={styles.articlesdetail__pickup__tag}>
-                        {
-                          tags.map(tag =>
-                            <li className={styles.articlesdetail__pickup__tag__item}>
-                              <Link href={{ pathname: '/articles', query: { tag: tag } }}><a className={styles.articlesdetail__pickup__tag__link}>#{`${tag}`}</a></Link>
-                            </li>
-                          )
-                        }
+                        {tags.map((tag) => (
+                          <li
+                            className={styles.articlesdetail__pickup__tag__item}
+                          >
+                            <Link
+                              href={{
+                                pathname: "/articles",
+                                query: { tag: tag },
+                              }}
+                            >
+                              <a
+                                className={
+                                  styles.articlesdetail__pickup__tag__link
+                                }
+                              >
+                                #{`${tag}`}
+                              </a>
+                            </Link>
+                          </li>
+                        ))}
                       </ul>
                     </li>
-                  )
-                })
-              }
-            </ul>
-            <div className={styles.articlesdetail__pickup__backLink}>
-              <Link href="/articles"><a>記事一覧へ</a></Link>
+                  );
+                })}
+              </ul>
+              <div className={styles.articlesdetail__pickup__backLink}>
+                <Link href="/articles">
+                  <a>記事一覧へ</a>
+                </Link>
+              </div>
             </div>
           </div>
-        </div>
-      </section>
-    </>
-  )
+        </section>
+      </>
+    );
   }
 };
 
 export async function getStaticProps({ params }) {
   const client = Client();
   const doc = await client.getByUID("article", params.uid);
-
+  console.group(doc);
   return {
     props: {
-      doc
-    }
+      doc,
+    },
   };
 }
 
 export async function getStaticPaths() {
-  const documents = await queryRepeatableDocuments((doc) => doc.type === 'article')
+  const documents = await queryRepeatableDocuments(
+    (doc) => doc.type === "article"
+  );
   return {
     // You can run a separate query here to get dynamic parameters from your documents.
-    paths: documents.map(doc => `/articles/${doc.uid}`),
-    fallback: true
+    paths: documents.map((doc) => `/articles/${doc.uid}`),
+    fallback: true,
   };
 }
 


### PR DESCRIPTION
prismic上で表示にしたSDGs目標をアイコンとして記事上に表示するようにしました。

以下コードブロック内のsdgsDisplayGeneratorで
` {key: value} `になっているものを
`{name: key, display: value}`に変換して、Map表示できる配列にして吐き出します。
 keyがgoal名(goal01 ~ goal17で表記)で、displayが表示非表示の t / f になってます。
``` javascript
export const sdgsDisplayGenerator = (sdgsObj) => {
  const sdgsGoals = Object.entries(sdgsObj).map(([key, value]) => ({
    name: key,
    display: value,
  }));
  return sdgsGoals;
};
```

そのnameを、表示する画像をsdgsIconSwitchに渡して画像のパスを切り替えて吐き出しています。